### PR TITLE
Perform fixed width array operations in type width units instead of byte units

### DIFF
--- a/encodings/fastlanes/src/bitpacking/array/unpack_iter.rs
+++ b/encodings/fastlanes/src/bitpacking/array/unpack_iter.rs
@@ -190,20 +190,14 @@ impl<'a, T: PhysicalPType, S: UnpackStrategy<T>> UnpackedChunks<'a, T, S> {
         if let Some(initial) = self.initial() {
             local_idx = initial.len();
 
-            // TODO(connor): use maybe_uninit_write_slice when it gets stabilized.
-            // SAFETY: &[T] and &[MaybeUninit<T>] have the same layout.
-            let init_initial: &[MaybeUninit<T>] = unsafe { mem::transmute(initial) };
-            output[..local_idx].copy_from_slice(init_initial);
+            output[..local_idx].write_copy_of_slice(initial);
         }
 
         local_idx = self.decode_full_chunks_into_at(output, local_idx);
 
         if let Some(trailer) = self.trailer() {
-            // TODO(connor): use maybe_uninit_write_slice when it gets stabilized.
-            // SAFETY: &[T] and &[MaybeUninit<T>] have the same layout.
-            let init_trailer: &[MaybeUninit<T>] = unsafe { mem::transmute(trailer) };
-            output[local_idx..][..init_trailer.len()].copy_from_slice(init_trailer);
-            local_idx += init_trailer.len();
+            output[local_idx..][..trailer.len()].write_copy_of_slice(trailer);
+            local_idx += trailer.len();
         }
 
         debug_assert_eq!(local_idx, self.len);

--- a/vortex-array/benches/take_slices_to_buffer_matrix.rs
+++ b/vortex-array/benches/take_slices_to_buffer_matrix.rs
@@ -4,7 +4,7 @@
 //! Microbenchmarks for primitive `take_slices_to_buffer` copy-loop variants.
 //!
 //! The matrix covers:
-//! - append via `BufferMut::copy_from_slice`, indexed cursor copy, and advancing pointer copy
+//! - append via `BufferMut::extend_from_slice`, indexed cursor copy, and advancing pointer copy
 //!   into spare output capacity
 //! - ordinary checked slicing vs a preverification pass followed by unchecked slicing
 //! - fixed-width short slices at the run counts used by the FSL take benchmarks
@@ -157,7 +157,7 @@ fn take_extend_safe(
 ) -> Buffer<u16> {
     let mut result = BufferMut::<u16>::with_capacity(output_len);
     for (&start, &length) in starts.iter().zip(lengths) {
-        result.copy_from_slice(&values[start..start + length]);
+        result.extend_from_slice(&values[start..start + length]);
     }
     result.freeze()
 }
@@ -223,7 +223,7 @@ fn take_preverify_extend_unchecked(
     for (&start, &length) in starts.iter().zip(lengths) {
         // SAFETY: `preverify` checked every source range.
         unsafe {
-            result.copy_from_slice(values.get_unchecked(start..start + length));
+            result.extend_from_slice(values.get_unchecked(start..start + length));
         }
     }
     result.freeze()

--- a/vortex-array/benches/take_slices_to_buffer_matrix.rs
+++ b/vortex-array/benches/take_slices_to_buffer_matrix.rs
@@ -4,7 +4,7 @@
 //! Microbenchmarks for primitive `take_slices_to_buffer` copy-loop variants.
 //!
 //! The matrix covers:
-//! - append via `BufferMut::extend_from_slice`, indexed cursor copy, and advancing pointer copy
+//! - append via `BufferMut::copy_from_slice`, indexed cursor copy, and advancing pointer copy
 //!   into spare output capacity
 //! - ordinary checked slicing vs a preverification pass followed by unchecked slicing
 //! - fixed-width short slices at the run counts used by the FSL take benchmarks
@@ -157,7 +157,7 @@ fn take_extend_safe(
 ) -> Buffer<u16> {
     let mut result = BufferMut::<u16>::with_capacity(output_len);
     for (&start, &length) in starts.iter().zip(lengths) {
-        result.extend_from_slice(&values[start..start + length]);
+        result.copy_from_slice(&values[start..start + length]);
     }
     result.freeze()
 }
@@ -223,7 +223,7 @@ fn take_preverify_extend_unchecked(
     for (&start, &length) in starts.iter().zip(lengths) {
         // SAFETY: `preverify` checked every source range.
         unsafe {
-            result.extend_from_slice(values.get_unchecked(start..start + length));
+            result.copy_from_slice(values.get_unchecked(start..start + length));
         }
     }
     result.freeze()
@@ -290,8 +290,7 @@ fn preverify(source_len: usize, starts: &[usize], lengths: &[usize], output_len:
 
 fn copy_to_spare(result: &mut BufferMut<u16>, cursor: usize, source: &[u16]) {
     let dst = &mut result.spare_capacity_mut()[cursor..][..source.len()];
-    // SAFETY: `dst` has exactly `source.len()` spare slots and does not overlap with source.
-    unsafe { copy_to_uninit(dst.as_mut_ptr().cast(), source) };
+    dst.write_copy_of_slice(source);
 }
 
 unsafe fn copy_to_spare_unchecked(result: &mut BufferMut<u16>, cursor: usize, source: &[u16]) {
@@ -301,8 +300,7 @@ unsafe fn copy_to_spare_unchecked(result: &mut BufferMut<u16>, cursor: usize, so
             .spare_capacity_mut()
             .get_unchecked_mut(cursor..cursor + source.len())
     };
-    // SAFETY: `dst` has exactly `source.len()` spare slots and does not overlap with source.
-    unsafe { copy_to_uninit(dst.as_mut_ptr().cast(), source) };
+    dst.write_copy_of_slice(source);
 }
 
 unsafe fn copy_to_uninit(dst: *mut u16, source: &[u16]) {

--- a/vortex-array/src/arrays/decimal/compute/fixed_width.rs
+++ b/vortex-array/src/arrays/decimal/compute/fixed_width.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use vortex_buffer::Buffer;
 use vortex_buffer::ByteBuffer;
 use vortex_error::VortexResult;
 
@@ -16,8 +17,10 @@ impl FixedWidthArray for Decimal {
         array.values_type().byte_width()
     }
 
-    fn values(array: ArrayView<'_, Self>) -> ByteBuffer {
-        array.buffer_handle().to_host_sync()
+    fn values<T: Copy>(array: ArrayView<'_, Self>) -> Buffer<T> {
+        let values = array.buffer_handle().to_host_sync();
+        let alignment = values.alignment();
+        Buffer::from_byte_buffer_aligned(values, alignment)
     }
 
     fn with_values(

--- a/vortex-array/src/arrays/filter/execute/byte_compress.rs
+++ b/vortex-array/src/arrays/filter/execute/byte_compress.rs
@@ -121,17 +121,14 @@ fn filter_chunk_into<T: Copy>(
         return;
     }
 
-    let out_ptr = out.spare_capacity_mut().as_mut_ptr();
     if chunk.len() == 8 && mask_byte == 0xFF {
         // All 8 selected, so bulk copy.
-        // SAFETY: write_pos + 8 <= capacity.
-        unsafe {
-            std::ptr::copy_nonoverlapping(chunk.as_ptr(), out_ptr.add(*write_pos).cast::<T>(), 8);
-        }
+        out.spare_capacity_mut()[*write_pos..][..8].write_copy_of_slice(chunk);
         *write_pos += 8;
         return;
     }
 
+    let out_ptr = out.spare_capacity_mut().as_mut_ptr();
     let (perm, count) = &BYTE_COMPRESS_LUT[mask_byte as usize];
     let count = *count as usize;
     debug_assert_eq!(mask_byte & !low_bits_mask(chunk.len()), 0);

--- a/vortex-array/src/arrays/filter/execute/slice.rs
+++ b/vortex-array/src/arrays/filter/execute/slice.rs
@@ -64,18 +64,14 @@ pub(super) fn filter_slice_by_bitmap<T: Copy>(slice: &[T], mask: &MaskValues) ->
     let output_len = mask.true_count();
     let mut out = BufferMut::<T>::with_capacity(output_len);
     let src_ptr = slice.as_ptr();
-    let out_ptr = out.spare_capacity_mut().as_mut_ptr().cast::<T>();
+    let spare = out.spare_capacity_mut();
     let mut write_pos = 0;
 
     for_each_mask_word(mask, |word, word_start, word_len| {
         let all_selected = low_bits_mask(word_len);
         debug_assert_eq!(word & !all_selected, 0);
         if word == all_selected {
-            // SAFETY: a full mask word selects `word_len` in-bounds source values and the output
-            // was allocated for every selected value.
-            unsafe {
-                ptr::copy_nonoverlapping(src_ptr.add(word_start), out_ptr.add(write_pos), word_len);
-            }
+            spare[write_pos..][..word_len].write_copy_of_slice(&slice[word_start..][..word_len]);
             write_pos += word_len;
         } else {
             let mut selected = word;
@@ -84,7 +80,9 @@ pub(super) fn filter_slice_by_bitmap<T: Copy>(slice: &[T], mask: &MaskValues) ->
                 // SAFETY: set bits are limited to `word_len`, and the output was allocated for
                 // exactly `mask.true_count()` values.
                 unsafe {
-                    out_ptr.add(write_pos).write(*src_ptr.add(index));
+                    spare
+                        .get_unchecked_mut(write_pos)
+                        .write(*src_ptr.add(index));
                 }
                 write_pos += 1;
                 selected &= selected - 1;
@@ -123,7 +121,7 @@ pub(super) fn filter_slice_by_slices<T: Copy>(
 ) -> Buffer<T> {
     let mut out = BufferMut::<T>::with_capacity(output_len);
     for (start, end) in slices {
-        out.extend_from_slice(&slice[*start..*end]);
+        out.copy_from_slice(&slice[*start..*end]);
     }
 
     out.freeze()

--- a/vortex-array/src/arrays/filter/execute/slice.rs
+++ b/vortex-array/src/arrays/filter/execute/slice.rs
@@ -121,7 +121,7 @@ pub(super) fn filter_slice_by_slices<T: Copy>(
 ) -> Buffer<T> {
     let mut out = BufferMut::<T>::with_capacity(output_len);
     for (start, end) in slices {
-        out.copy_from_slice(&slice[*start..*end]);
+        out.extend_from_slice(&slice[*start..*end]);
     }
 
     out.freeze()

--- a/vortex-array/src/arrays/fixed_width/array.rs
+++ b/vortex-array/src/arrays/fixed_width/array.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use vortex_buffer::Buffer;
 use vortex_buffer::ByteBuffer;
 use vortex_error::VortexResult;
 use vortex_error::vortex_ensure_eq;
@@ -22,10 +23,11 @@ pub(crate) trait FixedWidthArray: VTable {
     /// Returns the number of bytes each record occupies.
     fn byte_width(array: ArrayView<'_, Self>) -> usize;
 
-    /// Returns the records of `array` as a single host-resident byte buffer.
+    /// Returns the storage of `array` as a host-resident buffer of `T`, preserving its alignment.
     ///
     /// The returned buffer must contain exactly `array.len() * byte_width` bytes.
-    fn values(array: ArrayView<'_, Self>) -> ByteBuffer;
+    /// Its byte length and alignment must be compatible with `T`.
+    fn values<T: Copy>(array: ArrayView<'_, Self>) -> Buffer<T>;
 
     /// Rebuilds an array of this encoding from a records buffer, preserving the logical type of
     /// `array`.

--- a/vortex-array/src/arrays/fixed_width/filter.rs
+++ b/vortex-array/src/arrays/fixed_width/filter.rs
@@ -21,7 +21,7 @@ mod tests;
 
 pub(crate) fn filter<V: FixedWidthArray>(array: &Array<V>, mask: &MaskValuesRef) -> Array<V> {
     let array = array.as_view();
-    let values = filter_records(V::values(array), V::byte_width(array), mask.as_ref());
+    let values = filter_records(V::values::<u8>(array), V::byte_width(array), mask.as_ref());
     let validity = filter_validity(
         array
             .validity()

--- a/vortex-array/src/arrays/fixed_width/filter.rs
+++ b/vortex-array/src/arrays/fixed_width/filter.rs
@@ -1,19 +1,19 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use vortex_buffer::Buffer;
-use vortex_buffer::BufferMut;
 use vortex_buffer::ByteBuffer;
 use vortex_error::VortexExpect;
+use vortex_error::vortex_panic;
 use vortex_mask::MaskValues;
 use vortex_mask::MaskValuesRef;
 
 use super::FixedWidthArray;
-use super::match_each_record_width;
 use super::with_values;
 use crate::array::Array;
+use crate::array::ArrayView;
 use crate::arrays::filter::filter_buffer;
 use crate::arrays::filter::filter_validity;
+use crate::dtype::i256;
 
 #[cfg(test)]
 #[expect(clippy::cast_possible_truncation)]
@@ -21,7 +21,15 @@ mod tests;
 
 pub(crate) fn filter<V: FixedWidthArray>(array: &Array<V>, mask: &MaskValuesRef) -> Array<V> {
     let array = array.as_view();
-    let values = filter_records(V::values::<u8>(array), V::byte_width(array), mask.as_ref());
+    let values = match V::byte_width(array) {
+        1 => filter_records::<V, u8>(array, mask.as_ref()),
+        2 => filter_records::<V, u16>(array, mask.as_ref()),
+        4 => filter_records::<V, u32>(array, mask.as_ref()),
+        8 => filter_records::<V, u64>(array, mask.as_ref()),
+        16 => filter_records::<V, u128>(array, mask.as_ref()),
+        32 => filter_records::<V, i256>(array, mask.as_ref()),
+        byte_width => vortex_panic!("Unsupported fixed-width byte width: {byte_width}"),
+    };
     let validity = filter_validity(
         array
             .validity()
@@ -32,39 +40,15 @@ pub(crate) fn filter<V: FixedWidthArray>(array: &Array<V>, mask: &MaskValuesRef)
         .vortex_expect("filtering fixed-width values preserves array invariants")
 }
 
-fn filter_records(values: ByteBuffer, byte_width: usize, mask: &MaskValues) -> ByteBuffer {
+fn filter_records<V: FixedWidthArray, T: Copy>(
+    array: ArrayView<'_, V>,
+    mask: &MaskValues,
+) -> ByteBuffer {
+    let values = V::values::<T>(array);
     let alignment = values.alignment();
-
-    match_each_record_width!(
-        byte_width,
-        |W| {
-            let records = Buffer::<[u8; W]>::from_byte_buffer(values);
-            // `filter_buffer` picks between in-place compaction, cached indices/slices,
-            // byte-compress, and bitmap iteration based on record width and mask density.
-            let filtered = filter_buffer(records, mask);
-            filtered.into_byte_buffer().aligned(alignment)
-        },
-        _ => {
-            match values.try_into_mut() {
-                Ok(mut values) => {
-                    let mut destination = 0;
-                    mask.bit_buffer().for_each_set_index(|index| {
-                        let source = index * byte_width;
-                        values.copy_within(source..source + byte_width, destination);
-                        destination += byte_width;
-                    });
-                    values.truncate(destination);
-                    values.freeze().into_byte_buffer().aligned(alignment)
-                }
-                Err(values) => {
-                    let mut filtered = BufferMut::with_capacity(mask.true_count() * byte_width);
-                    mask.bit_buffer().for_each_set_index(|index| {
-                        let start = index * byte_width;
-                        filtered.extend_from_slice(&values[start..start + byte_width]);
-                    });
-                    filtered.freeze().into_byte_buffer().aligned(alignment)
-                }
-            }
-        }
-    )
+    // `filter_buffer` picks between in-place compaction, cached indices/slices,
+    // byte-compress, and bitmap iteration based on record width and mask density.
+    filter_buffer(values, mask)
+        .into_byte_buffer()
+        .aligned(alignment)
 }

--- a/vortex-array/src/arrays/fixed_width/filter/tests.rs
+++ b/vortex-array/src/arrays/fixed_width/filter/tests.rs
@@ -2,17 +2,21 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use rstest::rstest;
+use vortex_buffer::Alignment;
 use vortex_buffer::Buffer;
 use vortex_buffer::buffer;
+use vortex_error::VortexResult;
 use vortex_mask::Mask;
 
-use super::filter_records;
 use crate::ArrayRef;
 use crate::IntoArray;
 use crate::VortexSessionExecute;
+use crate::array::Array;
 use crate::array_session;
 use crate::arrays::DecimalArray;
 use crate::arrays::PrimitiveArray;
+use crate::arrays::fixed_width::FixedWidthArray;
+use crate::arrays::fixed_width::with_values;
 use crate::compute::conformance::filter::LARGE_SIZE;
 use crate::compute::conformance::filter::MEDIUM_SIZE;
 use crate::compute::conformance::filter::test_filter_conformance;
@@ -20,23 +24,39 @@ use crate::dtype::DecimalDType;
 use crate::dtype::i256;
 use crate::validity::Validity;
 
-#[test]
-fn filter_fallback_width_records() {
+#[rstest]
+#[case::u8(PrimitiveArray::from_iter([10u8, 20, 30, 40]))]
+#[case::u16(PrimitiveArray::from_iter([10u16, 20, 30, 40]))]
+#[case::u32(PrimitiveArray::from_iter([10u32, 20, 30, 40]))]
+#[case::u64(PrimitiveArray::from_iter([10u64, 20, 30, 40]))]
+#[case::u128(DecimalArray::new(
+    buffer![10i128, -20, -30, -40],
+    DecimalDType::new(19, 0),
+    Validity::NonNullable,
+))]
+#[case::i256(DecimalArray::new(
+    Buffer::from_iter([10, -20, -30, -40].map(|value| i256::from_parts(1, value))),
+    DecimalDType::new(76, 0),
+    Validity::NonNullable,
+))]
+fn filter_typed_records<V: FixedWidthArray>(#[case] array: Array<V>) -> VortexResult<()> {
     let Mask::Values(mask) = Mask::from_iter([true, false, true, false]) else {
         panic!("a mixed mask must have mask values");
     };
-    let expected = [0u8, 1, 2, 6, 7, 8];
-
-    // A uniquely owned buffer takes the in-place `copy_within` path.
-    let owned = Buffer::from_iter(0u8..12);
-    let filtered = filter_records(owned, 3, &mask);
-    assert_eq!(filtered.as_slice(), &expected);
-
-    // Retaining a second reference forces the copying path instead.
-    let shared = Buffer::from_iter(0u8..12);
-    let _retained = shared.clone();
-    let filtered = filter_records(shared, 3, &mask);
-    assert_eq!(filtered.as_slice(), &expected);
+    let byte_width = V::byte_width(array.as_view());
+    let values = V::values::<u8>(array.as_view()).aligned(Alignment::new(64));
+    let expected = values[..byte_width]
+        .iter()
+        .chain(&values[2 * byte_width..3 * byte_width])
+        .copied()
+        .collect::<Vec<_>>();
+    let array = with_values(array.as_view(), values, array.len(), Validity::NonNullable)?;
+    let alignment = V::values::<u8>(array.as_view()).alignment();
+    let filtered = super::filter(&array, &mask).into_array();
+    let buffers = filtered.buffers();
+    assert_eq!(buffers[0].as_slice(), expected);
+    assert_eq!(buffers[0].alignment(), alignment);
+    Ok(())
 }
 
 #[rstest]

--- a/vortex-array/src/arrays/fixed_width/mod.rs
+++ b/vortex-array/src/arrays/fixed_width/mod.rs
@@ -10,38 +10,3 @@ pub(crate) mod vtable;
 
 pub(crate) use self::array::FixedWidthArray;
 pub(crate) use self::array::with_values;
-
-/// Dispatches a runtime byte width to a compile-time `const $W: usize` for every record width
-/// with a dedicated fixed-width kernel, falling back to `$fallback` for any other width.
-macro_rules! match_each_record_width {
-    ($byte_width:expr, | $W:ident | $body:block,_ => $fallback:block) => {
-        match $byte_width {
-            1 => {
-                const $W: usize = 1;
-                $body
-            }
-            2 => {
-                const $W: usize = 2;
-                $body
-            }
-            4 => {
-                const $W: usize = 4;
-                $body
-            }
-            8 => {
-                const $W: usize = 8;
-                $body
-            }
-            16 => {
-                const $W: usize = 16;
-                $body
-            }
-            32 => {
-                const $W: usize = 32;
-                $body
-            }
-            _ => $fallback,
-        }
-    };
-}
-pub(crate) use match_each_record_width;

--- a/vortex-array/src/arrays/fixed_width/take/mod.rs
+++ b/vortex-array/src/arrays/fixed_width/take/mod.rs
@@ -15,6 +15,7 @@ use std::sync::LazyLock;
 use vortex_buffer::Buffer;
 use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
+use vortex_error::vortex_ensure;
 use vortex_mask::Mask;
 
 use self::records::take_byte_records;
@@ -38,6 +39,7 @@ use crate::builtins::ArrayBuiltins;
 use crate::dtype::DType;
 use crate::dtype::UnsignedPType;
 use crate::dtype::half::f16;
+use crate::dtype::i256;
 use crate::match_each_unsigned_integer_ptype;
 use crate::scalar::Scalar;
 
@@ -96,10 +98,19 @@ pub(crate) fn take<V: FixedWidthArray>(
     indices: &ArrayRef,
     ctx: &mut ExecutionCtx,
 ) -> VortexResult<Option<ArrayRef>> {
-    if let Some(piecewise_indices) = indices.as_opt::<PiecewiseSequence>()
-        && let Some(taken) = take_contiguous_ranges(array, piecewise_indices, indices, ctx)?
-    {
-        return Ok(Some(taken));
+    if let Some(piecewise_indices) = indices.as_opt::<PiecewiseSequence>() {
+        let taken = match V::byte_width(array) {
+            1 => take_contiguous_ranges::<V, u8>(array, piecewise_indices, indices, ctx)?,
+            2 => take_contiguous_ranges::<V, u16>(array, piecewise_indices, indices, ctx)?,
+            4 => take_contiguous_ranges::<V, u32>(array, piecewise_indices, indices, ctx)?,
+            8 => take_contiguous_ranges::<V, u64>(array, piecewise_indices, indices, ctx)?,
+            16 => take_contiguous_ranges::<V, u128>(array, piecewise_indices, indices, ctx)?,
+            32 => take_contiguous_ranges::<V, i256>(array, piecewise_indices, indices, ctx)?,
+            _ => None,
+        };
+        if taken.is_some() {
+            return Ok(taken);
+        }
     }
 
     let DType::Primitive(ptype, nullability) = indices.dtype() else {
@@ -135,7 +146,7 @@ pub(crate) fn take<V: FixedWidthArray>(
         .take(&indices.clone().into_array())?
         .and(indices_validity)?;
 
-    let source = V::values(array);
+    let source = V::values::<u8>(array);
     let values = match_each_unsigned_integer_ptype!(indices.ptype(), |I| {
         take_byte_records(
             &source,
@@ -149,7 +160,9 @@ pub(crate) fn take<V: FixedWidthArray>(
     ))
 }
 
-fn take_contiguous_ranges<V: FixedWidthArray>(
+// Avoid duplicating the starts/lengths dispatch in every record-width arm of `take`.
+#[inline(never)]
+fn take_contiguous_ranges<V: FixedWidthArray, T: Copy>(
     array: ArrayView<'_, V>,
     indices: ArrayView<'_, PiecewiseSequence>,
     indices_ref: &ArrayRef,
@@ -159,21 +172,17 @@ fn take_contiguous_ranges<V: FixedWidthArray>(
         return Ok(None);
     };
 
-    let values = V::values(array);
-    let byte_width = V::byte_width(array);
+    let values = V::values::<T>(array);
+    vortex_ensure!(
+        values.len() == array.len(),
+        "Fixed-width values buffer length does not match record count"
+    );
     let output_len = indices_ref.len();
     let taken = match lengths {
         Columnar::Constant(lengths) => {
             let length = constant_unsigned_usize(&lengths);
             match_each_unsigned_integer_ptype!(starts.ptype(), |S| {
-                take_slices_constant_length(
-                    &values,
-                    byte_width,
-                    array.len(),
-                    starts.as_slice::<S>(),
-                    length,
-                    output_len,
-                )
+                take_slices_constant_length(&values, starts.as_slice::<S>(), length, output_len)
             })
         }
         Columnar::Canonical(lengths) => {
@@ -182,8 +191,6 @@ fn take_contiguous_ranges<V: FixedWidthArray>(
                 match_each_unsigned_integer_ptype!(lengths.ptype(), |L| {
                     take_slices(
                         &values,
-                        byte_width,
-                        array.len(),
                         starts.as_slice::<S>(),
                         lengths.as_slice::<L>(),
                         output_len,
@@ -194,6 +201,6 @@ fn take_contiguous_ranges<V: FixedWidthArray>(
     }?;
     let validity = array.validity()?.take(indices_ref)?;
     Ok(Some(
-        with_values(array, taken, output_len, validity)?.into_array(),
+        with_values(array, taken.into_byte_buffer(), output_len, validity)?.into_array(),
     ))
 }

--- a/vortex-array/src/arrays/fixed_width/take/mod.rs
+++ b/vortex-array/src/arrays/fixed_width/take/mod.rs
@@ -18,7 +18,7 @@ use vortex_error::vortex_bail;
 use vortex_error::vortex_ensure;
 use vortex_mask::Mask;
 
-use self::records::take_byte_records;
+use self::records::take_records;
 use self::scalar::take_values_scalar;
 use self::slices::take_slices;
 use self::slices::take_slices_constant_length;
@@ -73,7 +73,9 @@ macro_rules! impl_fixed_width_take_value {
     };
 }
 
-impl_fixed_width_take_value!(u8, u16, u32, u64, i8, i16, i32, i64, f16, f32, f64,);
+impl_fixed_width_take_value!(
+    u8, u16, u32, u64, u128, i8, i16, i32, i64, i256, f16, f32, f64,
+);
 
 // SAFETY: Byte arrays have no padding and every byte is initialized.
 unsafe impl<const N: usize> FixedWidthTakeValue for [u8; N] {}
@@ -146,15 +148,15 @@ pub(crate) fn take<V: FixedWidthArray>(
         .take(&indices.clone().into_array())?
         .and(indices_validity)?;
 
-    let source = V::values::<u8>(array);
-    let values = match_each_unsigned_integer_ptype!(indices.ptype(), |I| {
-        take_byte_records(
-            &source,
-            V::byte_width(array),
-            array.len(),
-            indices.as_slice::<I>(),
-        )
-    })?;
+    let values = match V::byte_width(array) {
+        1 => take_records::<V, u8>(array, &indices)?,
+        2 => take_records::<V, u16>(array, &indices)?,
+        4 => take_records::<V, u32>(array, &indices)?,
+        8 => take_records::<V, u64>(array, &indices)?,
+        16 => take_records::<V, u128>(array, &indices)?,
+        32 => take_records::<V, i256>(array, &indices)?,
+        _ => return Ok(None),
+    };
     Ok(Some(
         with_values(array, values, indices.len(), validity)?.into_array(),
     ))

--- a/vortex-array/src/arrays/fixed_width/take/records.rs
+++ b/vortex-array/src/arrays/fixed_width/take/records.rs
@@ -1,49 +1,30 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use vortex_buffer::Buffer;
-use vortex_buffer::BufferMut;
 use vortex_buffer::ByteBuffer;
 use vortex_error::VortexResult;
-use vortex_error::vortex_err;
+use vortex_error::vortex_ensure;
 
+use super::FixedWidthTakeValue;
 use super::take_values;
-use crate::arrays::fixed_width::match_each_record_width;
-use crate::dtype::UnsignedPType;
+use crate::array::ArrayView;
+use crate::arrays::PrimitiveArray;
+use crate::arrays::fixed_width::FixedWidthArray;
+use crate::match_each_unsigned_integer_ptype;
 
-pub(super) fn take_byte_records<I: UnsignedPType>(
-    values: &ByteBuffer,
-    byte_width: usize,
-    record_count: usize,
-    indices: &[I],
+// Avoid duplicating the indices dispatch in every record-width arm of `take`.
+#[inline(never)]
+pub(super) fn take_records<V: FixedWidthArray, T: FixedWidthTakeValue>(
+    array: ArrayView<'_, V>,
+    indices: &PrimitiveArray,
 ) -> VortexResult<ByteBuffer> {
-    let alignment = values.alignment();
-
-    match_each_record_width!(
-        byte_width,
-        |W| {
-            let records = Buffer::<[u8; W]>::from_byte_buffer(values.clone());
-            debug_assert_eq!(records.len(), record_count);
-            Ok(take_values(records.as_slice(), indices)
-                .into_byte_buffer()
-                .aligned(alignment))
-        },
-        _ => {
-            let output_len = indices
-                .len()
-                .checked_mul(byte_width)
-                .ok_or_else(|| vortex_err!("Fixed-width take output length overflows usize"))?;
-            let mut result = BufferMut::<u8>::with_capacity(output_len);
-            for index in indices {
-                let index = index.as_();
-                assert!(
-                    index < record_count,
-                    "take index {index} out of bounds for length {record_count}"
-                );
-                let start = index * byte_width;
-                result.extend_from_slice(&values[start..start + byte_width]);
-            }
-            Ok(result.freeze().into_byte_buffer().aligned(alignment))
-        }
-    )
+    let values = V::values::<T>(array);
+    vortex_ensure!(
+        values.len() == array.len(),
+        "Fixed-width values buffer length does not match record count"
+    );
+    let taken = match_each_unsigned_integer_ptype!(indices.ptype(), |I| {
+        take_values(values.as_slice(), indices.as_slice::<I>())
+    });
+    Ok(taken.into_byte_buffer().aligned(values.alignment()))
 }

--- a/vortex-array/src/arrays/fixed_width/take/slices.rs
+++ b/vortex-array/src/arrays/fixed_width/take/slices.rs
@@ -2,37 +2,33 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use itertools::Itertools as _;
+use vortex_buffer::Buffer;
 use vortex_buffer::BufferMut;
-use vortex_buffer::ByteBuffer;
 use vortex_error::VortexResult;
 use vortex_error::vortex_ensure;
 use vortex_error::vortex_err;
 
 use crate::dtype::UnsignedPType;
 
-pub(super) fn take_slices<S: UnsignedPType, L: UnsignedPType>(
-    values: &ByteBuffer,
-    byte_width: usize,
-    record_count: usize,
+pub(super) fn take_slices<T: Copy, S: UnsignedPType, L: UnsignedPType>(
+    values: &Buffer<T>,
     starts: &[S],
     lengths: &[L],
     output_len: usize,
-) -> VortexResult<ByteBuffer> {
+) -> VortexResult<Buffer<T>> {
     let slices = starts
         .iter()
         .zip_eq(lengths)
         .map(|(&start, &length)| (start.as_(), length.as_()));
-    copy_slices(values, byte_width, record_count, slices, output_len)
+    copy_slices(values, slices, output_len)
 }
 
-pub(super) fn take_slices_constant_length<S: UnsignedPType>(
-    values: &ByteBuffer,
-    byte_width: usize,
-    record_count: usize,
+pub(super) fn take_slices_constant_length<T: Copy, S: UnsignedPType>(
+    values: &Buffer<T>,
     starts: &[S],
     length: usize,
     output_len: usize,
-) -> VortexResult<ByteBuffer> {
+) -> VortexResult<Buffer<T>> {
     let computed_len = starts
         .len()
         .checked_mul(length)
@@ -43,34 +39,25 @@ pub(super) fn take_slices_constant_length<S: UnsignedPType>(
     );
     copy_slices(
         values,
-        byte_width,
-        record_count,
         starts.iter().map(|start| (start.as_(), length)),
         output_len,
     )
 }
 
-fn copy_slices(
-    values: &ByteBuffer,
-    byte_width: usize,
-    record_count: usize,
+// Keeping this kernel separate improves the take_fsl benchmark's small-range copies.
+#[inline(never)]
+fn copy_slices<T: Copy>(
+    values: &Buffer<T>,
     slices: impl IntoIterator<Item = (usize, usize)>,
     output_len: usize,
-) -> VortexResult<ByteBuffer> {
-    let input_byte_len = record_count
-        .checked_mul(byte_width)
-        .ok_or_else(|| vortex_err!("Fixed-width values buffer length overflows usize"))?;
-    vortex_ensure!(
-        values.len() == input_byte_len,
-        "Fixed-width values buffer length does not match record count"
-    );
-
-    let output_byte_len = output_len
-        .checked_mul(byte_width)
+) -> VortexResult<Buffer<T>> {
+    output_len
+        .checked_mul(size_of::<T>())
         .ok_or_else(|| vortex_err!("PiecewiseSequenceArray output length overflows usize"))?;
-    let mut result = BufferMut::<u8>::with_capacity_aligned(output_byte_len, values.alignment());
-    let spare = &mut result.spare_capacity_mut()[..output_byte_len];
+    let mut result = BufferMut::<T>::with_capacity_aligned(output_len, values.alignment());
+    let spare = &mut result.spare_capacity_mut()[..output_len];
     let mut cursor = 0usize;
+    let record_count = values.len();
 
     for (start, length) in slices {
         let end = start
@@ -80,21 +67,17 @@ fn copy_slices(
             end <= record_count,
             "PiecewiseSequenceArray slice {start}..{end} exceeds array length {record_count}"
         );
-        // These multiplications cannot overflow because `end <= record_count` and the complete
-        // values buffer length was checked above.
-        let byte_start = start * byte_width;
-        let byte_length = length * byte_width;
-        let source = &values[byte_start..][..byte_length];
-        spare[cursor..][..source.len()].write_copy_of_slice(source);
-        cursor += source.len();
+        let source = &values[start..end];
+        spare[cursor..][..length].write_copy_of_slice(source);
+        cursor += length;
     }
 
     // SAFETY: The loop initialized the prefix `0..cursor` of the spare capacity.
     unsafe { result.set_len(cursor) };
     vortex_ensure!(
-        result.len() == output_byte_len,
-        "PiecewiseSequenceArray expanded length {} does not match declared length {output_byte_len}",
+        result.len() == output_len,
+        "PiecewiseSequenceArray expanded length {} does not match declared length {output_len}",
         result.len()
     );
-    Ok(result.freeze().into_byte_buffer())
+    Ok(result.freeze())
 }

--- a/vortex-array/src/arrays/fixed_width/take/slices.rs
+++ b/vortex-array/src/arrays/fixed_width/take/slices.rs
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use std::ptr;
-
 use itertools::Itertools as _;
 use vortex_buffer::BufferMut;
 use vortex_buffer::ByteBuffer;
@@ -87,15 +85,7 @@ fn copy_slices(
         let byte_start = start * byte_width;
         let byte_length = length * byte_width;
         let source = &values[byte_start..][..byte_length];
-        // SAFETY: `source` and the checked spare-capacity range have equal lengths and do not
-        // overlap.
-        unsafe {
-            ptr::copy_nonoverlapping(
-                source.as_ptr(),
-                spare[cursor..][..source.len()].as_mut_ptr().cast::<u8>(),
-                source.len(),
-            );
-        }
+        spare[cursor..][..source.len()].write_copy_of_slice(source);
         cursor += source.len();
     }
 

--- a/vortex-array/src/arrays/fixed_width/take/tests.rs
+++ b/vortex-array/src/arrays/fixed_width/take/tests.rs
@@ -9,19 +9,21 @@ use vortex_buffer::Buffer;
 use vortex_buffer::buffer;
 use vortex_error::VortexResult;
 
-use super::records::take_byte_records;
 use super::slices::take_slices;
 use super::slices::take_slices_constant_length;
 use super::take_values;
 use crate::ArrayRef;
 use crate::IntoArray;
 use crate::VortexSessionExecute;
+use crate::array::Array;
 use crate::array_session;
 use crate::arrays::BoolArray;
 use crate::arrays::ConstantArray;
 use crate::arrays::DecimalArray;
 use crate::arrays::PiecewiseSequenceArray;
 use crate::arrays::PrimitiveArray;
+use crate::arrays::fixed_width::FixedWidthArray;
+use crate::arrays::fixed_width::with_values;
 use crate::assert_arrays_eq;
 use crate::compute::conformance::take::test_take_conformance;
 use crate::dtype::DecimalDType;
@@ -43,31 +45,55 @@ fn take_eight_byte_values() {
 }
 
 #[rstest]
-#[case(1)]
-#[case(2)]
-#[case(4)]
-#[case(8)]
-#[case(16)]
-#[case(32)]
-#[case::fallback(3)]
-#[case::fallback_wide(12)]
-fn take_runtime_width_records(#[case] byte_width: usize) -> VortexResult<()> {
-    let values = Buffer::from_iter((0u8..).take(3 * byte_width));
+#[case::u8(PrimitiveArray::from_iter([10u8, 20, 30]))]
+#[case::u16(PrimitiveArray::from_iter([10u16, 20, 30]))]
+#[case::u32(PrimitiveArray::from_iter([10u32, 20, 30]))]
+#[case::u64(PrimitiveArray::from_iter([10u64, 20, 30]))]
+#[case::u128(DecimalArray::new(
+    buffer![10i128, -20, -30],
+    DecimalDType::new(19, 0),
+    Validity::NonNullable,
+))]
+#[case::i256(DecimalArray::new(
+    Buffer::from_iter([10, -20, -30].map(|value| i256::from_parts(1, value))),
+    DecimalDType::new(76, 0),
+    Validity::NonNullable,
+))]
+fn take_typed_records<V: FixedWidthArray>(
+    #[case] array: Array<V>,
+    #[values(
+        PrimitiveArray::from_iter([2u8, 0]),
+        PrimitiveArray::from_iter([2u16, 0]),
+        PrimitiveArray::from_iter([2u32, 0]),
+        PrimitiveArray::from_iter([2u64, 0])
+    )]
+    indices: PrimitiveArray,
+) -> VortexResult<()> {
+    let mut ctx = array_session().create_execution_ctx();
+    let byte_width = V::byte_width(array.as_view());
+    let values = V::values::<u8>(array.as_view()).aligned(Alignment::new(64));
     let expected = values[2 * byte_width..3 * byte_width]
         .iter()
         .chain(&values[..byte_width])
         .copied()
         .collect::<Vec<_>>();
-    let taken = take_byte_records(&values.into_byte_buffer(), byte_width, 3, &[2u32, 0])?;
-    assert_eq!(taken.as_slice(), expected);
+    let array = with_values(array.as_view(), values, array.len(), Validity::NonNullable)?;
+    let alignment = V::values::<u8>(array.as_view()).alignment();
+    let taken = super::take(array.as_view(), &indices.into_array(), &mut ctx)?
+        .expect("native-width take must be supported");
+    let buffers = taken.buffers();
+    assert_eq!(buffers[0].as_slice(), expected);
+    assert_eq!(buffers[0].alignment(), alignment);
     Ok(())
 }
 
 #[test]
-#[should_panic(expected = "take index 3 out of bounds for length 3")]
-fn fallback_take_rejects_out_of_bounds_index() {
-    let values = Buffer::from_iter((0u8..).take(9)).into_byte_buffer();
-    drop(take_byte_records(&values, 3, 3, &[3u32]));
+#[should_panic(expected = "out of bounds")]
+fn typed_take_rejects_out_of_bounds_index() {
+    let mut ctx = array_session().create_execution_ctx();
+    let array = PrimitiveArray::from_iter([10u32, 20, 30]);
+    let indices = PrimitiveArray::from_iter([3u32]).into_array();
+    drop(super::take(array.as_view(), &indices, &mut ctx));
 }
 
 #[rstest]

--- a/vortex-array/src/arrays/fixed_width/take/tests.rs
+++ b/vortex-array/src/arrays/fixed_width/take/tests.rs
@@ -1,7 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use std::fmt::Debug;
+
 use rstest::rstest;
+use vortex_buffer::Alignment;
 use vortex_buffer::Buffer;
 use vortex_buffer::buffer;
 use vortex_error::VortexResult;
@@ -22,6 +25,7 @@ use crate::arrays::PrimitiveArray;
 use crate::assert_arrays_eq;
 use crate::compute::conformance::take::test_take_conformance;
 use crate::dtype::DecimalDType;
+use crate::dtype::half::f16;
 use crate::dtype::i256;
 use crate::validity::Validity;
 
@@ -66,26 +70,32 @@ fn fallback_take_rejects_out_of_bounds_index() {
     drop(take_byte_records(&values, 3, 3, &[3u32]));
 }
 
-#[test]
-fn take_variable_length_slices() -> VortexResult<()> {
-    let values = buffer![10u8, 11, 12, 13, 14].into_byte_buffer();
-    let taken = take_slices(&values, 1, 5, &[1u32, 3], &[2u32, 1], 3)?;
-    assert_eq!(taken.as_slice(), &[11, 12, 13]);
+#[rstest]
+#[case::u8(buffer![10u8, 11, 12, 13, 14])]
+#[case::u16(buffer![10u16, 11, 12, 13, 14])]
+#[case::u32(buffer![10u32, 11, 12, 13, 14])]
+#[case::u64(buffer![10u64, 11, 12, 13, 14])]
+#[case::u128(buffer![10u128, 11, 12, 13, 14])]
+#[case::i256(Buffer::from_iter((10..15).map(i256::from_i128)))]
+#[case::three_bytes(buffer![[10u8; 3], [11; 3], [12; 3], [13; 3], [14; 3]])]
+#[case::twelve_bytes(buffer![[10u8; 12], [11; 12], [12; 12], [13; 12], [14; 12]])]
+fn take_typed_slices<T: Copy + Debug + Eq>(#[case] values: Buffer<T>) -> VortexResult<()> {
+    let values = values.aligned(Alignment::new(64));
+    let taken = take_slices(&values, &[1u32, 3], &[2u32, 1], 3)?;
+    assert_eq!(taken.as_slice(), &values[1..4]);
+    assert_eq!(taken.alignment(), values.alignment());
+
+    let taken = take_slices_constant_length(&values, &[0u32, 3], 2, 4)?;
+    let expected = [&values[..2], &values[3..]].concat();
+    assert_eq!(taken.as_slice(), expected);
+    assert_eq!(taken.alignment(), values.alignment());
     Ok(())
 }
 
 #[test]
 fn variable_length_slices_validate_output_length() {
-    let values = buffer![10u8, 11, 12, 13].into_byte_buffer();
-    assert!(take_slices(&values, 1, 4, &[0u32, 2], &[1u32, 1], 3).is_err());
-}
-
-#[test]
-fn take_constant_length_slices() -> VortexResult<()> {
-    let values = buffer![10u8, 11, 12, 13, 14].into_byte_buffer();
-    let taken = take_slices_constant_length(&values, 1, 5, &[0u32, 3], 2, 4)?;
-    assert_eq!(taken.as_slice(), &[10, 11, 13, 14]);
-    Ok(())
+    let values = buffer![10u8, 11, 12, 13];
+    assert!(take_slices(&values, &[0u32, 2], &[1u32, 1], 3).is_err());
 }
 
 #[test]
@@ -131,38 +141,39 @@ fn null_index_skips_out_of_bounds_decimal_value() -> VortexResult<()> {
     Ok(())
 }
 
-#[test]
-fn decimal_i256_take_consumes_piecewise_indices() -> VortexResult<()> {
+#[rstest]
+#[case::u8(PrimitiveArray::from_iter([10u8, 20, 30, 40, 50]).into_array())]
+#[case::f16(PrimitiveArray::from_iter([10.0, -20.0, 30.0, -40.0, 50.0].map(f16::from_f32)).into_array())]
+#[case::f32(PrimitiveArray::from_iter([10f32, -20.0, 30.0, -40.0, 50.0]).into_array())]
+#[case::f64(PrimitiveArray::from_iter([10f64, -20.0, 30.0, -40.0, 50.0]).into_array())]
+#[case::decimal_i128(DecimalArray::new(
+    buffer![100i128, -200, 300, -400, 500],
+    DecimalDType::new(19, 2),
+    Validity::NonNullable,
+).into_array())]
+#[case::decimal_i256(DecimalArray::new(
+    Buffer::from_iter([100, -200, 300, -400, 500].map(i256::from_i128)),
+    DecimalDType::new(76, 2),
+    Validity::NonNullable,
+).into_array())]
+fn fixed_width_take_consumes_piecewise_indices(
+    #[case] values: ArrayRef,
+    #[values(false, true)] constant_length: bool,
+) -> VortexResult<()> {
     let mut ctx = array_session().create_execution_ctx();
-    let decimal_dtype = DecimalDType::new(76, 2);
-    let values = DecimalArray::new(
-        buffer![
-            i256::from_i128(100),
-            i256::from_i128(200),
-            i256::from_i128(300),
-            i256::from_i128(400),
-            i256::from_i128(500),
-        ],
-        decimal_dtype,
-        Validity::NonNullable,
-    );
     let starts = PrimitiveArray::from_iter([1u64, 3]).into_array();
-    let lengths = PrimitiveArray::from_iter([2u64, 1]).into_array();
+    let (lengths, output_len) = if constant_length {
+        (ConstantArray::new(2u64, 2).into_array(), 4)
+    } else {
+        (PrimitiveArray::from_iter([2u64, 1]).into_array(), 3)
+    };
     let multipliers = ConstantArray::new(1u64, 2).into_array();
-    let indices = PiecewiseSequenceArray::try_new(starts, lengths, multipliers, 3)?.into_array();
+    let indices =
+        PiecewiseSequenceArray::try_new(starts, lengths, multipliers, output_len)?.into_array();
 
     let taken = values.take(indices)?;
 
-    let expected = DecimalArray::new(
-        buffer![
-            i256::from_i128(200),
-            i256::from_i128(300),
-            i256::from_i128(400),
-        ],
-        decimal_dtype,
-        Validity::NonNullable,
-    );
-    assert_arrays_eq!(taken, expected, &mut ctx);
+    assert_arrays_eq!(taken, values.slice(1..1 + output_len)?, &mut ctx);
     Ok(())
 }
 

--- a/vortex-array/src/arrays/primitive/compute/fixed_width.rs
+++ b/vortex-array/src/arrays/primitive/compute/fixed_width.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use vortex_buffer::Buffer;
 use vortex_buffer::ByteBuffer;
 use vortex_error::VortexResult;
 
@@ -15,8 +16,10 @@ impl FixedWidthArray for Primitive {
         array.ptype().byte_width()
     }
 
-    fn values(array: ArrayView<'_, Self>) -> ByteBuffer {
-        array.buffer_handle().to_host_sync()
+    fn values<T: Copy>(array: ArrayView<'_, Self>) -> Buffer<T> {
+        let values = array.buffer_handle().to_host_sync();
+        let alignment = values.alignment();
+        Buffer::from_byte_buffer_aligned(values, alignment)
     }
 
     fn with_values(

--- a/vortex-array/src/arrays/varbin/compute/take.rs
+++ b/vortex-array/src/arrays/varbin/compute/take.rs
@@ -389,7 +389,7 @@ fn take<Index: IntegerPType, Offset: IntegerPType>(
         let stop = offsets[idx + 1]
             .to_usize()
             .vortex_expect("Failed to cast max offset to usize");
-        new_data.copy_from_slice(&data[start..stop]);
+        new_data.extend_from_slice(&data[start..stop]);
     }
 
     let array_validity = Validity::from(dtype.nullability());
@@ -798,7 +798,7 @@ fn take_nullable<Index: IntegerPType, Offset: IntegerPType>(
         let stop = offsets[data_idx + 1]
             .to_usize()
             .vortex_expect("Failed to cast max offset to usize");
-        new_data.copy_from_slice(&data[start..stop]);
+        new_data.extend_from_slice(&data[start..stop]);
     }
 
     let array_validity = Validity::from(validity_buffer.freeze());

--- a/vortex-array/src/arrays/varbin/compute/take.rs
+++ b/vortex-array/src/arrays/varbin/compute/take.rs
@@ -2,7 +2,6 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use std::iter;
-use std::ptr;
 use std::sync::Arc;
 
 use itertools::Itertools as _;
@@ -390,7 +389,7 @@ fn take<Index: IntegerPType, Offset: IntegerPType>(
         let stop = offsets[idx + 1]
             .to_usize()
             .vortex_expect("Failed to cast max offset to usize");
-        new_data.extend_from_slice(&data[start..stop]);
+        new_data.copy_from_slice(&data[start..stop]);
     }
 
     let array_validity = Validity::from(dtype.nullability());
@@ -642,14 +641,7 @@ where
         let byte_start = offset_range[0].as_();
         let byte_end = offset_range[length].as_();
         let src = &data[byte_start..byte_end];
-        // SAFETY: `src` and the checked `spare` range have equal lengths and cannot overlap.
-        unsafe {
-            ptr::copy_nonoverlapping(
-                src.as_ptr(),
-                spare[cursor..][..src.len()].as_mut_ptr().cast::<u8>(),
-                src.len(),
-            );
-        }
+        spare[cursor..][..src.len()].write_copy_of_slice(src);
         cursor += src.len();
     }
     // SAFETY: the loop initialized the prefix `0..cursor` of the spare capacity.
@@ -735,14 +727,7 @@ where
         let byte_start = offset_range[0].as_();
         let byte_end = offset_range[length].as_();
         let src = &data[byte_start..byte_end];
-        // SAFETY: `src` and the checked `spare` range have equal lengths and cannot overlap.
-        unsafe {
-            ptr::copy_nonoverlapping(
-                src.as_ptr(),
-                spare[cursor..][..src.len()].as_mut_ptr().cast::<u8>(),
-                src.len(),
-            );
-        }
+        spare[cursor..][..src.len()].write_copy_of_slice(src);
         cursor += src.len();
     }
     // SAFETY: the loop initialized the prefix `0..cursor` of the spare capacity.
@@ -813,7 +798,7 @@ fn take_nullable<Index: IntegerPType, Offset: IntegerPType>(
         let stop = offsets[data_idx + 1]
             .to_usize()
             .vortex_expect("Failed to cast max offset to usize");
-        new_data.extend_from_slice(&data[start..stop]);
+        new_data.copy_from_slice(&data[start..stop]);
     }
 
     let array_validity = Validity::from(validity_buffer.freeze());

--- a/vortex-array/src/arrays/varbinview/compute/take.rs
+++ b/vortex-array/src/arrays/varbinview/compute/take.rs
@@ -2,7 +2,6 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use std::iter;
-use std::ptr;
 use std::sync::Arc;
 
 use itertools::Itertools as _;
@@ -180,16 +179,7 @@ where
     for &start in starts {
         let start = start.as_();
         let src = &source[start..][..length];
-        // SAFETY: `src` and the checked `spare` range have equal lengths and cannot overlap.
-        unsafe {
-            ptr::copy_nonoverlapping(
-                src.as_ptr(),
-                spare[cursor..][..src.len()]
-                    .as_mut_ptr()
-                    .cast::<BinaryView>(),
-                src.len(),
-            );
-        }
+        spare[cursor..][..src.len()].write_copy_of_slice(src);
         cursor += src.len();
     }
     // SAFETY: the loop initialized the prefix `0..cursor` of the spare capacity.
@@ -219,16 +209,7 @@ where
         let start = start.as_();
         let length = length.as_();
         let src = &source[start..][..length];
-        // SAFETY: `src` and the checked `spare` range have equal lengths and cannot overlap.
-        unsafe {
-            ptr::copy_nonoverlapping(
-                src.as_ptr(),
-                spare[cursor..][..src.len()]
-                    .as_mut_ptr()
-                    .cast::<BinaryView>(),
-                src.len(),
-            );
-        }
+        spare[cursor..][..src.len()].write_copy_of_slice(src);
         cursor += src.len();
     }
     // SAFETY: the loop initialized the prefix `0..cursor` of the spare capacity.

--- a/vortex-array/src/builders/primitive.rs
+++ b/vortex-array/src/builders/primitive.rs
@@ -160,7 +160,7 @@ impl<T: NativePType> PrimitiveBuilder<T> {
             "Cannot append primitive array with different ptype"
         );
 
-        self.values.copy_from_slice(array.as_slice::<T>());
+        self.values.extend_from_slice(array.as_slice::<T>());
         self.nulls.append_validity_mask(
             &array
                 .as_ref()

--- a/vortex-array/src/builders/primitive.rs
+++ b/vortex-array/src/builders/primitive.rs
@@ -160,7 +160,7 @@ impl<T: NativePType> PrimitiveBuilder<T> {
             "Cannot append primitive array with different ptype"
         );
 
-        self.values.extend_from_slice(array.as_slice::<T>());
+        self.values.copy_from_slice(array.as_slice::<T>());
         self.nulls.append_validity_mask(
             &array
                 .as_ref()
@@ -321,14 +321,11 @@ impl<T> UninitRange<'_, T> {
             "tried to copy a slice into a `UninitRange` past its boundary"
         );
 
-        // SAFETY: &[T] and &[MaybeUninit<T>] have the same layout.
-        let uninit_src: &[MaybeUninit<T>] = unsafe { std::mem::transmute(src) };
-
         // Note: spare_capacity_mut() returns the spare capacity starting from the current length,
         // so we just use local_offset directly.
         let dst =
             &mut self.builder.values.spare_capacity_mut()[local_offset..local_offset + src.len()];
-        dst.copy_from_slice(uninit_src);
+        dst.write_copy_of_slice(src);
     }
 
     /// Get a mutable slice of uninitialized memory at the specified offset within this range.

--- a/vortex-buffer/src/allocation.rs
+++ b/vortex-buffer/src/allocation.rs
@@ -83,7 +83,7 @@ impl BufferAllocatorRef {
     }
 
     /// Copy values into a mutable buffer made by this allocator.
-    pub fn copy_from<T>(&self, values: impl AsRef<[T]>) -> BufferMut<T> {
+    pub fn copy_from<T: Copy>(&self, values: impl AsRef<[T]>) -> BufferMut<T> {
         BufferMut::copy_from_in(values, self.clone())
     }
 }
@@ -182,7 +182,7 @@ impl StaticBufferAllocator {
     }
 
     /// Copy values into a mutable buffer made by the static allocator.
-    pub fn copy_from<T>(values: impl AsRef<[T]>) -> BufferMut<T> {
+    pub fn copy_from<T: Copy>(values: impl AsRef<[T]>) -> BufferMut<T> {
         BufferMut::copy_from(values)
     }
 }

--- a/vortex-buffer/src/buffer.rs
+++ b/vortex-buffer/src/buffer.rs
@@ -167,12 +167,18 @@ impl<T> Buffer<T> {
     /// of the provided `Vec<T>` while maintaining the ability to convert it back into a mutable
     /// buffer. We could fix this by forking `Bytes`, or in many other complex ways, but for now
     /// callers should prefer to construct `Buffer<T>` from a `BufferMut<T>`.
-    pub fn copy_from(values: impl AsRef<[T]>) -> Self {
+    pub fn copy_from(values: impl AsRef<[T]>) -> Self
+    where
+        T: Copy,
+    {
         BufferMut::copy_from(values).freeze()
     }
 
     /// Returns a new `Buffer<T>` copied with the provided allocator.
-    pub fn copy_from_in(values: impl AsRef<[T]>, allocator: BufferAllocatorRef) -> Self {
+    pub fn copy_from_in(values: impl AsRef<[T]>, allocator: BufferAllocatorRef) -> Self
+    where
+        T: Copy,
+    {
         BufferMut::copy_from_in(values, allocator).freeze()
     }
 
@@ -182,7 +188,10 @@ impl<T> Buffer<T> {
     /// `alignment`. Use [`copy_from_preferred_aligned`] to control the over-alignment.
     ///
     /// [`copy_from_preferred_aligned`]: Self::copy_from_preferred_aligned
-    pub fn copy_from_aligned(values: impl AsRef<[T]>, alignment: Alignment) -> Self {
+    pub fn copy_from_aligned(values: impl AsRef<[T]>, alignment: Alignment) -> Self
+    where
+        T: Copy,
+    {
         Self::copy_from_preferred_aligned(values, alignment, Some(Alignment::DEFAULT_ALIGNMENT))
     }
 
@@ -194,7 +203,10 @@ impl<T> Buffer<T> {
         values: impl AsRef<[T]>,
         alignment: Alignment,
         preferred_alignment: Option<Alignment>,
-    ) -> Self {
+    ) -> Self
+    where
+        T: Copy,
+    {
         BufferMut::copy_from_preferred_aligned(values, alignment, preferred_alignment).freeze()
     }
 
@@ -670,7 +682,10 @@ impl<T> Buffer<T> {
     }
 
     /// Convert self into `BufferMut<T>`, cloning the data if there are multiple strong references.
-    pub fn into_mut(self) -> BufferMut<T> {
+    pub fn into_mut(self) -> BufferMut<T>
+    where
+        T: Copy,
+    {
         self.try_into_mut().unwrap_or_else(|buffer| {
             let allocator = buffer.allocator().clone();
             BufferMut::<T>::copy_from_aligned_in(&buffer, buffer.alignment, allocator)
@@ -683,7 +698,10 @@ impl<T> Buffer<T> {
     }
 
     /// Return a `Buffer<T>` with the given alignment. Where possible, this will be zero-copy.
-    pub fn aligned(mut self, alignment: Alignment) -> Self {
+    pub fn aligned(mut self, alignment: Alignment) -> Self
+    where
+        T: Copy,
+    {
         if alignment.is_ptr_aligned(self.as_ptr()) {
             self.alignment = alignment;
             self

--- a/vortex-buffer/src/buffer_mut.rs
+++ b/vortex-buffer/src/buffer_mut.rs
@@ -712,8 +712,10 @@ impl<T> BufferMut<T> {
         T: Copy,
     {
         self.reserve(slice.len());
-        // SAFETY: reserve guarantees at least slice.len() spare slots.
-        let dst = unsafe { self.spare_capacity_mut().get_unchecked_mut(..slice.len()) };
+        let dst = self
+            .spare_capacity_mut()
+            .get_mut(..slice.len())
+            .vortex_expect("reserve guarantees sufficient spare capacity");
         dst.write_copy_of_slice(slice);
         self.length += slice.len();
     }

--- a/vortex-buffer/src/buffer_mut.rs
+++ b/vortex-buffer/src/buffer_mut.rs
@@ -308,12 +308,18 @@ impl<T> BufferMut<T> {
     }
 
     /// Create a mutable scalar buffer by copying the contents of the slice.
-    pub fn copy_from(other: impl AsRef<[T]>) -> Self {
+    pub fn copy_from(other: impl AsRef<[T]>) -> Self
+    where
+        T: Copy,
+    {
         Self::copy_from_in(other, BufferAllocatorRef::statically_allocated())
     }
 
     /// Create a mutable scalar buffer by copying with the given allocator.
-    pub fn copy_from_in(other: impl AsRef<[T]>, allocator: BufferAllocatorRef) -> Self {
+    pub fn copy_from_in(other: impl AsRef<[T]>, allocator: BufferAllocatorRef) -> Self
+    where
+        T: Copy,
+    {
         Self::copy_from_aligned_in(other, Alignment::of::<T>(), allocator)
     }
 
@@ -327,7 +333,10 @@ impl<T> BufferMut<T> {
     /// ## Panics
     ///
     /// Panics when the requested alignment isn't itself aligned to type T.
-    pub fn copy_from_aligned(other: impl AsRef<[T]>, alignment: Alignment) -> Self {
+    pub fn copy_from_aligned(other: impl AsRef<[T]>, alignment: Alignment) -> Self
+    where
+        T: Copy,
+    {
         Self::copy_from_aligned_in(other, alignment, BufferAllocatorRef::statically_allocated())
     }
 
@@ -336,7 +345,10 @@ impl<T> BufferMut<T> {
         other: impl AsRef<[T]>,
         alignment: Alignment,
         allocator: BufferAllocatorRef,
-    ) -> Self {
+    ) -> Self
+    where
+        T: Copy,
+    {
         Self::copy_from_preferred_aligned_in(
             other,
             alignment,
@@ -357,7 +369,10 @@ impl<T> BufferMut<T> {
         other: impl AsRef<[T]>,
         alignment: Alignment,
         preferred_alignment: Option<Alignment>,
-    ) -> Self {
+    ) -> Self
+    where
+        T: Copy,
+    {
         Self::copy_from_preferred_aligned_in(
             other,
             alignment,
@@ -372,7 +387,10 @@ impl<T> BufferMut<T> {
         alignment: Alignment,
         preferred_alignment: Option<Alignment>,
         allocator: BufferAllocatorRef,
-    ) -> Self {
+    ) -> Self
+    where
+        T: Copy,
+    {
         if !alignment.is_aligned_to(Alignment::of::<T>()) {
             vortex_panic!("Given alignment is not aligned to type T")
         }
@@ -383,7 +401,7 @@ impl<T> BufferMut<T> {
             preferred_alignment,
             allocator,
         );
-        buffer.extend_from_slice(other);
+        buffer.copy_from_slice(other);
         debug_assert_eq!(buffer.alignment(), alignment);
         buffer
     }
@@ -663,7 +681,13 @@ impl<T> BufferMut<T> {
         self.length += n;
     }
 
-    /// Appends a slice of type `T`, growing the internal buffer as needed.
+    /// Appends a slice by cloning its elements, growing the internal buffer as needed.
+    ///
+    /// Prefer [`Self::copy_from_slice`] when `T` implements `Copy`.
+    ///
+    /// # Panics
+    ///
+    /// If cloning an element panics, the buffer's length and existing values are unchanged.
     ///
     /// # Example:
     ///
@@ -676,16 +700,52 @@ impl<T> BufferMut<T> {
     /// assert_eq!(builder.len(), 3);
     /// ```
     #[inline]
-    pub fn extend_from_slice(&mut self, slice: &[T]) {
+    pub fn extend_from_slice(&mut self, slice: &[T])
+    where
+        T: Clone,
+    {
         self.reserve(slice.len());
-        // SAFETY: reserve made the destination valid and non-overlapping for slice.len() values.
-        unsafe {
-            std::ptr::copy_nonoverlapping(
-                slice.as_ptr(),
-                self.as_mut_ptr().add(self.length),
-                slice.len(),
-            );
-        }
+        // SAFETY: reserve guarantees at least slice.len() spare slots.
+        let dst = unsafe { self.spare_capacity_mut().get_unchecked_mut(..slice.len()) };
+        dst.write_clone_of_slice(slice);
+        self.length += slice.len();
+    }
+
+    /// Appends a slice by copying its elements, growing the internal buffer as needed.
+    ///
+    /// This does not call [`Clone::clone`]. For types that only implement `Clone`, use
+    /// [`Self::extend_from_slice`].
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use vortex_buffer::BufferMut;
+    ///
+    /// let mut buffer = BufferMut::from_iter([1, 2]);
+    /// buffer.copy_from_slice(&[3, 4]);
+    /// assert_eq!(buffer.as_slice(), &[1, 2, 3, 4]);
+    /// ```
+    ///
+    /// Elements must implement `Copy`, even when they implement `Clone`.
+    ///
+    /// ```compile_fail,E0277
+    /// use vortex_buffer::BufferMut;
+    ///
+    /// #[derive(Clone)]
+    /// struct NotCopy(u32);
+    ///
+    /// let mut buffer = BufferMut::with_capacity(1);
+    /// buffer.copy_from_slice(&[NotCopy(1)]);
+    /// ```
+    #[inline]
+    pub fn copy_from_slice(&mut self, slice: &[T])
+    where
+        T: Copy,
+    {
+        self.reserve(slice.len());
+        // SAFETY: reserve guarantees at least slice.len() spare slots.
+        let dst = unsafe { self.spare_capacity_mut().get_unchecked_mut(..slice.len()) };
+        dst.write_copy_of_slice(slice);
         self.length += slice.len();
     }
 
@@ -734,14 +794,17 @@ impl<T> BufferMut<T> {
     /// If the data is already properly aligned, this is a metadata-only operation.
     ///
     /// If the data is not aligned, we copy it into a new allocation.
-    pub fn aligned(self, alignment: Alignment) -> Self {
+    pub fn aligned(self, alignment: Alignment) -> Self
+    where
+        T: Copy,
+    {
         if self.as_ptr().align_offset(alignment.as_usize()) == 0 {
             Self { alignment, ..self }
         } else {
             let capacity = self.capacity();
             let allocator = self.allocation.allocator().clone();
             let mut aligned = Self::with_capacity_aligned_in(capacity, alignment, allocator);
-            aligned.extend_from_slice(&self);
+            aligned.copy_from_slice(&self);
             aligned.capacity = capacity;
             aligned
         }
@@ -777,7 +840,7 @@ impl<T> BufferMut<T> {
     }
 }
 
-impl<T> Clone for BufferMut<T> {
+impl<T: Clone> Clone for BufferMut<T> {
     fn clone(&self) -> Self {
         let mut buffer = BufferMut::<T>::with_capacity_aligned_in(
             self.capacity(),
@@ -994,10 +1057,85 @@ impl<T> FromIterator<T> for BufferMut<T> {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
+    use std::cell::Cell;
+    use std::panic::AssertUnwindSafe;
+    use std::panic::catch_unwind;
+
     use crate::Alignment;
     use crate::BufferMut;
     use crate::buffer_mut;
+
+    #[derive(Clone, Debug, PartialEq)]
+    struct CloneOnly(u32);
+
+    #[derive(Copy, Debug, PartialEq)]
+    struct CopyWithCloneCounter<'a> {
+        value: u32,
+        clones: &'a Cell<usize>,
+        panic_at: Option<usize>,
+    }
+
+    #[allow(clippy::non_canonical_clone_impl)]
+    impl Clone for CopyWithCloneCounter<'_> {
+        fn clone(&self) -> Self {
+            self.clones.set(self.clones.get() + 1);
+            assert_ne!(Some(self.clones.get()), self.panic_at, "clone panicked");
+            *self
+        }
+    }
+
+    #[test]
+    fn extend_from_slice_supports_clone_only() {
+        let mut buffer = BufferMut::empty();
+        buffer.push(CloneOnly(1));
+        buffer.extend_from_slice(&[CloneOnly(2), CloneOnly(3)]);
+
+        assert_eq!(
+            buffer.as_slice(),
+            &[CloneOnly(1), CloneOnly(2), CloneOnly(3)]
+        );
+        assert_eq!(buffer.clone().as_slice(), buffer.as_slice());
+    }
+
+    #[test]
+    fn copy_from_slice_skips_clone() {
+        let clones = Cell::new(0);
+        let source = [CopyWithCloneCounter {
+            value: 42,
+            clones: &clones,
+            panic_at: None,
+        }];
+        let mut buffer = BufferMut::empty();
+        buffer.extend_from_slice(&source);
+        assert_eq!(clones.get(), 1);
+
+        buffer.copy_from_slice(&source);
+        buffer.copy_from_slice(&[]);
+        assert_eq!(clones.get(), 1);
+        assert_eq!(buffer.as_slice(), &[source[0], source[0]]);
+    }
+
+    #[test]
+    fn extend_from_slice_preserves_buffer_on_clone_panic() {
+        let clones = Cell::new(0);
+        let source = [CopyWithCloneCounter {
+            value: 42,
+            clones: &clones,
+            panic_at: Some(2),
+        }; 2];
+        let mut buffer = BufferMut::empty();
+        buffer.push(source[0]);
+
+        let result = catch_unwind(AssertUnwindSafe(|| buffer.extend_from_slice(&source)));
+        assert!(result.is_err());
+        assert_eq!(clones.get(), 2);
+        assert_eq!(buffer.as_slice(), &source[..1]);
+
+        buffer.copy_from_slice(&source);
+        assert_eq!(clones.get(), 2);
+        assert_eq!(buffer.as_slice(), &[source[0]; 3]);
+    }
 
     #[test]
     fn capacity() {

--- a/vortex-buffer/src/buffer_mut.rs
+++ b/vortex-buffer/src/buffer_mut.rs
@@ -401,7 +401,7 @@ impl<T> BufferMut<T> {
             preferred_alignment,
             allocator,
         );
-        buffer.copy_from_slice(other);
+        buffer.extend_from_slice(other);
         debug_assert_eq!(buffer.alignment(), alignment);
         buffer
     }
@@ -681,40 +681,9 @@ impl<T> BufferMut<T> {
         self.length += n;
     }
 
-    /// Appends a slice by cloning its elements, growing the internal buffer as needed.
-    ///
-    /// Prefer [`Self::copy_from_slice`] when `T` implements `Copy`.
-    ///
-    /// # Panics
-    ///
-    /// If cloning an element panics, the buffer's length and existing values are unchanged.
-    ///
-    /// # Example:
-    ///
-    /// ```
-    /// # use vortex_buffer::BufferMut;
-    ///
-    /// let mut builder = BufferMut::<u16>::with_capacity(10);
-    /// builder.extend_from_slice(&[42, 44, 46]);
-    ///
-    /// assert_eq!(builder.len(), 3);
-    /// ```
-    #[inline]
-    pub fn extend_from_slice(&mut self, slice: &[T])
-    where
-        T: Clone,
-    {
-        self.reserve(slice.len());
-        // SAFETY: reserve guarantees at least slice.len() spare slots.
-        let dst = unsafe { self.spare_capacity_mut().get_unchecked_mut(..slice.len()) };
-        dst.write_clone_of_slice(slice);
-        self.length += slice.len();
-    }
-
     /// Appends a slice by copying its elements, growing the internal buffer as needed.
     ///
-    /// This does not call [`Clone::clone`]. For types that only implement `Clone`, use
-    /// [`Self::extend_from_slice`].
+    /// This does not call [`Clone::clone`].
     ///
     /// # Example
     ///
@@ -722,7 +691,7 @@ impl<T> BufferMut<T> {
     /// use vortex_buffer::BufferMut;
     ///
     /// let mut buffer = BufferMut::from_iter([1, 2]);
-    /// buffer.copy_from_slice(&[3, 4]);
+    /// buffer.extend_from_slice(&[3, 4]);
     /// assert_eq!(buffer.as_slice(), &[1, 2, 3, 4]);
     /// ```
     ///
@@ -735,10 +704,10 @@ impl<T> BufferMut<T> {
     /// struct NotCopy(u32);
     ///
     /// let mut buffer = BufferMut::with_capacity(1);
-    /// buffer.copy_from_slice(&[NotCopy(1)]);
+    /// buffer.extend_from_slice(&[NotCopy(1)]);
     /// ```
     #[inline]
-    pub fn copy_from_slice(&mut self, slice: &[T])
+    pub fn extend_from_slice(&mut self, slice: &[T])
     where
         T: Copy,
     {
@@ -804,7 +773,7 @@ impl<T> BufferMut<T> {
             let capacity = self.capacity();
             let allocator = self.allocation.allocator().clone();
             let mut aligned = Self::with_capacity_aligned_in(capacity, alignment, allocator);
-            aligned.copy_from_slice(&self);
+            aligned.extend_from_slice(&self);
             aligned.capacity = capacity;
             aligned
         }
@@ -840,7 +809,7 @@ impl<T> BufferMut<T> {
     }
 }
 
-impl<T: Clone> Clone for BufferMut<T> {
+impl<T: Copy> Clone for BufferMut<T> {
     fn clone(&self) -> Self {
         let mut buffer = BufferMut::<T>::with_capacity_aligned_in(
             self.capacity(),
@@ -1059,82 +1028,40 @@ impl<T> FromIterator<T> for BufferMut<T> {
 #[cfg(test)]
 mod tests {
     use std::cell::Cell;
-    use std::panic::AssertUnwindSafe;
-    use std::panic::catch_unwind;
 
     use crate::Alignment;
     use crate::BufferMut;
     use crate::buffer_mut;
 
-    #[derive(Clone, Debug, PartialEq)]
-    struct CloneOnly(u32);
-
     #[derive(Copy, Debug, PartialEq)]
     struct CopyWithCloneCounter<'a> {
         value: u32,
         clones: &'a Cell<usize>,
-        panic_at: Option<usize>,
     }
 
     #[allow(clippy::non_canonical_clone_impl)]
     impl Clone for CopyWithCloneCounter<'_> {
         fn clone(&self) -> Self {
             self.clones.set(self.clones.get() + 1);
-            assert_ne!(Some(self.clones.get()), self.panic_at, "clone panicked");
             *self
         }
     }
 
     #[test]
-    fn extend_from_slice_supports_clone_only() {
-        let mut buffer = BufferMut::empty();
-        buffer.push(CloneOnly(1));
-        buffer.extend_from_slice(&[CloneOnly(2), CloneOnly(3)]);
-
-        assert_eq!(
-            buffer.as_slice(),
-            &[CloneOnly(1), CloneOnly(2), CloneOnly(3)]
-        );
-        assert_eq!(buffer.clone().as_slice(), buffer.as_slice());
-    }
-
-    #[test]
-    fn copy_from_slice_skips_clone() {
+    fn extend_from_slice_skips_clone() {
         let clones = Cell::new(0);
         let source = [CopyWithCloneCounter {
             value: 42,
             clones: &clones,
-            panic_at: None,
         }];
         let mut buffer = BufferMut::empty();
         buffer.extend_from_slice(&source);
-        assert_eq!(clones.get(), 1);
-
-        buffer.copy_from_slice(&source);
-        buffer.copy_from_slice(&[]);
-        assert_eq!(clones.get(), 1);
+        buffer.extend_from_slice(&source);
+        buffer.extend_from_slice(&[]);
+        assert_eq!(clones.get(), 0);
         assert_eq!(buffer.as_slice(), &[source[0], source[0]]);
-    }
-
-    #[test]
-    fn extend_from_slice_preserves_buffer_on_clone_panic() {
-        let clones = Cell::new(0);
-        let source = [CopyWithCloneCounter {
-            value: 42,
-            clones: &clones,
-            panic_at: Some(2),
-        }; 2];
-        let mut buffer = BufferMut::empty();
-        buffer.push(source[0]);
-
-        let result = catch_unwind(AssertUnwindSafe(|| buffer.extend_from_slice(&source)));
-        assert!(result.is_err());
-        assert_eq!(clones.get(), 2);
-        assert_eq!(buffer.as_slice(), &source[..1]);
-
-        buffer.copy_from_slice(&source);
-        assert_eq!(clones.get(), 2);
-        assert_eq!(buffer.as_slice(), &[source[0]; 3]);
+        assert_eq!(buffer.clone().as_slice(), buffer.as_slice());
+        assert_eq!(clones.get(), 0);
     }
 
     #[test]

--- a/vortex-buffer/src/const.rs
+++ b/vortex-buffer/src/const.rs
@@ -20,12 +20,18 @@ impl<T, const A: usize> ConstBuffer<T, A> {
     }
 
     /// Align the given buffer (possibly with a copy) and return a new `ConstBuffer`.
-    pub fn align_from<B: Into<Buffer<T>>>(buf: B) -> Self {
+    pub fn align_from<B: Into<Buffer<T>>>(buf: B) -> Self
+    where
+        T: Copy,
+    {
         Self(buf.into().aligned(Self::alignment()))
     }
 
     /// Create a new [`ConstBuffer`] with a copy from the provided slice.
-    pub fn copy_from<B: AsRef<[T]>>(buf: B) -> Self {
+    pub fn copy_from<B: AsRef<[T]>>(buf: B) -> Self
+    where
+        T: Copy,
+    {
         Self(Buffer::<T>::copy_from_aligned(buf, Self::alignment()))
     }
 


### PR DESCRIPTION
Instead of doing all offset calculation in byte units we do them in type T units
which is less errorprone



---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>