### PR TITLE
fix(duckdb): guard integer aggregate pushdown against overflow

### DIFF
--- a/vortex-duckdb/cpp/multi_file_reader.cpp
+++ b/vortex-duckdb/cpp/multi_file_reader.cpp
@@ -112,7 +112,9 @@ void VortexReaderInterface::BindReader(ClientContext &context,
     const void *const ffi_file = initial_reader.ffi_file->DataPtr();
     duckdb_bind_result ffi_result = reinterpret_cast<duckdb_bind_result>(&result);
 
-    duckdb_vx_data ffi_bind_data = duckdb_reader_bind(ffi_file, ffi_result, &error);
+    // Capture this before pruning can replace the file list with a different single file.
+    const bool single_file = bind_data.file_list->GetExpandResult() == FileExpandResult::SINGLE_FILE;
+    duckdb_vx_data ffi_bind_data = duckdb_reader_bind(ffi_file, single_file, ffi_result, &error);
     if (error) {
         throw BinderException(IntoErrString(error));
     }

--- a/vortex-duckdb/include/vortex.h
+++ b/vortex-duckdb/include/vortex.h
@@ -50,6 +50,7 @@ extern duckdb_vx_data duckdb_table_function_init_local(const void *bind, const v
 
 extern
 duckdb_vx_data duckdb_reader_bind(const void *first_file,
+                                  bool single_file,
                                   duckdb_bind_result result,
                                   duckdb_vx_error *error_out);
 

--- a/vortex-duckdb/src/convert/expr.rs
+++ b/vortex-duckdb/src/convert/expr.rs
@@ -505,6 +505,8 @@ pub enum PushedAggregate {
     Min,
     Max,
     Sum,
+    /// DuckDB's `sum_no_overflow`, which proves `i64` bounds for integer inputs.
+    SumNoOverflow,
     Mean,
     // Also used for ANY_VALUE() which is allowed by definition
     First,
@@ -517,7 +519,7 @@ impl Display for PushedAggregate {
         match self {
             PushedAggregate::Min => f.write_str("min"),
             PushedAggregate::Max => f.write_str("max"),
-            PushedAggregate::Sum => f.write_str("sum"),
+            PushedAggregate::Sum | PushedAggregate::SumNoOverflow => f.write_str("sum"),
             PushedAggregate::Mean => f.write_str("mean"),
             PushedAggregate::First => f.write_str("first"),
             PushedAggregate::Count => f.write_str("count"),
@@ -536,7 +538,7 @@ impl PushedAggregate {
         Ok(match self {
             Self::Min => Box::new(Accumulator::try_new(Min, opts, dtype)?),
             Self::Max => Box::new(Accumulator::try_new(Max, opts, dtype)?),
-            Self::Sum => Box::new(Accumulator::try_new(SumV2, opts, dtype)?),
+            Self::Sum | Self::SumNoOverflow => Box::new(Accumulator::try_new(SumV2, opts, dtype)?),
             Self::Mean => Box::new(Accumulator::try_new(
                 Mean::combined(),
                 PairOptions(opts, opts),
@@ -561,7 +563,8 @@ pub fn try_from_projection_aggregate(
     Ok(Some(match agg.aggregate_function.name() {
         "min" => PushedAggregate::Min,
         "max" => PushedAggregate::Max,
-        "sum" | "sum_no_overflow" => PushedAggregate::Sum,
+        "sum" => PushedAggregate::Sum,
+        "sum_no_overflow" => PushedAggregate::SumNoOverflow,
         "avg" | "mean" => PushedAggregate::Mean,
         "first" | "any_value" => PushedAggregate::First,
         "count" => PushedAggregate::Count,

--- a/vortex-duckdb/src/e2e_test/aggregate_pushdown_test.rs
+++ b/vortex-duckdb/src/e2e_test/aggregate_pushdown_test.rs
@@ -47,22 +47,15 @@ fn connection() -> VortexResult<Connection> {
     Ok(conn)
 }
 
-#[cfg(target_pointer_width = "64")]
-#[rstest]
-#[case::signed_overflow(i32::MAX.into(), 4_294_967_299, 9_223_372_039_002_259_453, f64::from(i32::MAX))]
-#[case::signed_underflow(i32::MIN.into(), 4_294_967_297, -9_223_372_039_002_259_456, f64::from(i32::MIN))]
-#[case::unsigned_overflow(u32::MAX.into(), 4_294_967_298, 18_446_744_078_004_518_910, f64::from(u32::MAX))]
-fn test_integer_aggregates_exceed_vortex_sum_range(
-    #[case] value: Scalar,
-    #[case] len: usize,
-    #[case] expected_sum: i128,
-    #[case] expected_mean: f64,
+#[track_caller]
+fn check_aggregates(
+    conn: &Connection,
+    query: &str,
+    expected_sum: i128,
+    expected_mean: f64,
 ) -> VortexResult<()> {
-    let file = constant_file(value, len)?;
-    let conn = connection()?;
-    let query = format!("SELECT sum(i), avg(i) FROM '{}'", file.path().display());
     let chunk = conn
-        .query(&query)?
+        .query(query)?
         .into_iter()
         .next()
         .ok_or_else(|| vortex_err!("Expected one aggregate row"))?;
@@ -91,27 +84,9 @@ fn test_integer_aggregates_exceed_vortex_sum_range(
     Ok(())
 }
 
-#[rstest]
-#[case::i8(1i8.into())]
-#[case::i16(1i16.into())]
-#[case::i32(1i32.into())]
-#[case::i64(1i64.into())]
-#[case::u8(1u8.into())]
-#[case::u16(1u16.into())]
-#[case::u32(1u32.into())]
-#[case::u64(1u64.into())]
-fn test_integer_sum_and_mean_stay_in_duckdb(
-    #[case] value: Scalar,
-    #[values("sum", "avg")] aggregate: &str,
-) -> VortexResult<()> {
-    let file = constant_file(value, 3)?;
-    let conn = connection()?;
-    let query = format!(
-        "EXPLAIN SELECT {aggregate}(i) FROM '{}'",
-        file.path().display(),
-    );
+fn explain(conn: &Connection, query: &str) -> VortexResult<String> {
     let mut plan = String::new();
-    for chunk in conn.query(&query)? {
+    for chunk in conn.query(&format!("EXPLAIN {query}"))? {
         for row in 0..chunk.len() {
             let value = chunk
                 .get_vector(1)
@@ -120,7 +95,139 @@ fn test_integer_sum_and_mean_stay_in_duckdb(
             plan.push_str(&value.as_string());
         }
     }
-    assert!(plan.contains("UNGROUPED_AGGREGATE"), "{plan}");
+    Ok(plan)
+}
 
+#[cfg(target_pointer_width = "64")]
+#[rstest]
+#[case::signed_overflow(i32::MAX.into(), 4_294_967_299, 9_223_372_039_002_259_453, f64::from(i32::MAX))]
+#[case::signed_underflow(i32::MIN.into(), 4_294_967_297, -9_223_372_039_002_259_456, f64::from(i32::MIN))]
+#[case::unsigned_overflow(u32::MAX.into(), 4_294_967_298, 18_446_744_078_004_518_910, f64::from(u32::MAX))]
+fn test_integer_aggregates_exceed_vortex_sum_range(
+    #[case] value: Scalar,
+    #[case] len: usize,
+    #[case] expected_sum: i128,
+    #[case] expected_mean: f64,
+) -> VortexResult<()> {
+    let file = constant_file(value, len)?;
+    let conn = connection()?;
+    let query = format!("SELECT sum(i), avg(i) FROM '{}'", file.path().display());
+    check_aggregates(&conn, &query, expected_sum, expected_mean)
+}
+
+// DuckDB casts prevent mixed-query pushdown for i8 and unsigned inputs.
+#[rstest]
+#[case::i8(i8::MAX.into(), false)]
+#[case::i16(i16::MAX.into(), true)]
+#[case::i32(i32::MAX.into(), true)]
+#[case::i64(i64::MAX.into(), false)]
+#[case::u8(u8::MAX.into(), false)]
+#[case::u16(u16::MAX.into(), false)]
+#[case::u32(u32::MAX.into(), false)]
+#[case::u64(u64::MAX.into(), false)]
+fn test_mixed_integer_aggregate_pushdown(
+    #[case] value: Scalar,
+    #[case] pushed: bool,
+    #[values("sum", "avg", "mean")] aggregate: &str,
+) -> VortexResult<()> {
+    let file = constant_file(value, 3)?;
+    let conn = connection()?;
+    let plan = explain(
+        &conn,
+        &format!(
+            "SELECT {aggregate}(i), min(i), max(i), count(i) FROM '{}'",
+            file.path().display(),
+        ),
+    )?;
+    assert_eq!(!plan.contains("UNGROUPED_AGGREGATE"), pushed, "{plan}");
     Ok(())
+}
+
+#[rstest]
+#[case::without_statistics(false)]
+#[case::with_statistics(true)]
+fn test_sum_no_overflow_pushdown(#[case] statistics: bool) -> VortexResult<()> {
+    let file = constant_file(1i64.into(), 3)?;
+    let conn = connection()?;
+    if statistics {
+        conn.query("SET disabled_optimizers='';")?;
+    }
+    let query = format!("SELECT sum(i) FROM '{}'", file.path().display());
+    let plan = explain(&conn, &query)?;
+    assert_eq!(!plan.contains("UNGROUPED_AGGREGATE"), statistics, "{plan}");
+    let chunk = conn
+        .query(&query)?
+        .into_iter()
+        .next()
+        .ok_or_else(|| vortex_err!("Expected one aggregate row"))?;
+    let sum = chunk
+        .get_vector(0)
+        .get_value(0, 1)
+        .ok_or_else(|| vortex_err!("Expected a sum value"))?
+        .extract();
+    assert!(matches!(sum, ExtractedValue::HugeInt(3)), "{sum:?}");
+    Ok(())
+}
+
+#[cfg(target_pointer_width = "64")]
+#[rstest]
+#[case::fits(4_294_967_296, true)]
+#[case::overflows(4_294_967_297, false)]
+fn test_integer_aggregate_row_bound_boundary(
+    #[case] len: usize,
+    #[case] pushed: bool,
+    #[values("", " WHERE i < 0")] filter: &str,
+) -> VortexResult<()> {
+    let file = constant_file(i32::MIN.into(), len)?;
+    let conn = connection()?;
+    let query = format!(
+        "SELECT sum(i), avg(i) FROM '{}'{filter}",
+        file.path().display()
+    );
+    let plan = explain(&conn, &query)?;
+    assert_eq!(!plan.contains("UNGROUPED_AGGREGATE"), pushed, "{plan}");
+    check_aggregates(
+        &conn,
+        &query,
+        i128::from(i32::MIN) * len as i128,
+        f64::from(i32::MIN),
+    )
+}
+
+#[cfg(target_pointer_width = "64")]
+#[rstest]
+fn test_multiple_files_do_not_use_first_file_row_bound(
+    #[values(false, true)] prune_first: bool,
+) -> VortexResult<()> {
+    let first = constant_file(1i32.into(), 1)?;
+    let second = constant_file(i32::MAX.into(), 4_294_967_299)?;
+    let conn = connection()?;
+    let mut query = format!(
+        "SELECT sum(i), avg(i) FROM read_vortex(['{}', '{}'], filename=true)",
+        first.path().display(),
+        second.path().display()
+    );
+    if prune_first {
+        query.push_str(&format!(" WHERE filename = '{}'", second.path().display()));
+    }
+    let plan = explain(&conn, &query)?;
+    assert!(plan.contains("UNGROUPED_AGGREGATE"), "{plan}");
+    let expected_sum = 9_223_372_039_002_259_453i128 + i128::from(!prune_first);
+    let count = 4_294_967_299u64 + u64::from(!prune_first);
+    check_aggregates(
+        &conn,
+        &query,
+        expected_sum,
+        expected_sum as f64 / count as f64,
+    )
+}
+
+#[test]
+fn test_single_row_i64_aggregates() -> VortexResult<()> {
+    let file = constant_file(i64::MAX.into(), 1)?;
+    let conn = connection()?;
+    let query = format!("SELECT sum(i), avg(i) FROM '{}'", file.path().display());
+    let plan = explain(&conn, &query)?;
+    assert!(!plan.contains("UNGROUPED_AGGREGATE"), "{plan}");
+    check_aggregates(&conn, &query, i128::from(i64::MAX), i64::MAX as f64)
 }

--- a/vortex-duckdb/src/e2e_test/aggregate_pushdown_test.rs
+++ b/vortex-duckdb/src/e2e_test/aggregate_pushdown_test.rs
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+//! Integer aggregates must retain DuckDB's wider accumulation range.
+
+use std::sync::Arc;
+
+use rstest::rstest;
+use tempfile::NamedTempFile;
+use vortex::array::IntoArray;
+use vortex::array::arrays::ConstantArray;
+use vortex::array::arrays::StructArray;
+use vortex::error::VortexResult;
+use vortex::error::vortex_err;
+use vortex::file::WriteOptionsSessionExt;
+use vortex::layout::layouts::flat::writer::FlatLayoutStrategy;
+use vortex::scalar::Scalar;
+
+use crate::RUNTIME;
+use crate::SESSION;
+use crate::duckdb::Connection;
+use crate::duckdb::Database;
+use crate::duckdb::ExtractedValue;
+
+fn constant_file(value: Scalar, len: usize) -> VortexResult<NamedTempFile> {
+    let file = NamedTempFile::with_suffix(".vortex")?;
+    let array = StructArray::try_from_iter([("i", ConstantArray::new(value, len).into_array())])?
+        .into_array();
+
+    // Store the constant directly so billions of logical rows need only a small fixture.
+    SESSION
+        .write_options()
+        .with_strategy(Arc::new(FlatLayoutStrategy::default()))
+        .blocking(&*RUNTIME)
+        .write(file.reopen()?, array.to_array_iterator())?;
+
+    Ok(file)
+}
+
+fn connection() -> VortexResult<Connection> {
+    let db = Database::open_in_memory()?;
+    db.register_vortex_scan_replacement()?;
+    crate::initialize(&db)?;
+    let conn = db.connect()?;
+    conn.query("SET threads=1; SET disabled_optimizers='statistics_propagation';")?;
+
+    Ok(conn)
+}
+
+#[cfg(target_pointer_width = "64")]
+#[rstest]
+#[case::signed_overflow(i32::MAX.into(), 4_294_967_299, 9_223_372_039_002_259_453, f64::from(i32::MAX))]
+#[case::signed_underflow(i32::MIN.into(), 4_294_967_297, -9_223_372_039_002_259_456, f64::from(i32::MIN))]
+#[case::unsigned_overflow(u32::MAX.into(), 4_294_967_298, 18_446_744_078_004_518_910, f64::from(u32::MAX))]
+fn test_integer_aggregates_exceed_vortex_sum_range(
+    #[case] value: Scalar,
+    #[case] len: usize,
+    #[case] expected_sum: i128,
+    #[case] expected_mean: f64,
+) -> VortexResult<()> {
+    let file = constant_file(value, len)?;
+    let conn = connection()?;
+    let query = format!("SELECT sum(i), avg(i) FROM '{}'", file.path().display());
+    let chunk = conn
+        .query(&query)?
+        .into_iter()
+        .next()
+        .ok_or_else(|| vortex_err!("Expected one aggregate row"))?;
+    assert_eq!(chunk.len(), 1);
+
+    let sum = chunk
+        .get_vector(0)
+        .get_value(0, 1)
+        .ok_or_else(|| vortex_err!("Expected a sum value"))?
+        .extract();
+    assert!(
+        matches!(sum, ExtractedValue::HugeInt(actual) if actual == expected_sum),
+        "{sum:?}"
+    );
+
+    let mean = chunk
+        .get_vector(1)
+        .get_value(0, 1)
+        .ok_or_else(|| vortex_err!("Expected a mean value"))?
+        .extract();
+    assert!(
+        matches!(mean, ExtractedValue::Double(actual) if actual == expected_mean),
+        "{mean:?}"
+    );
+
+    Ok(())
+}
+
+#[rstest]
+#[case::i8(1i8.into())]
+#[case::i16(1i16.into())]
+#[case::i32(1i32.into())]
+#[case::i64(1i64.into())]
+#[case::u8(1u8.into())]
+#[case::u16(1u16.into())]
+#[case::u32(1u32.into())]
+#[case::u64(1u64.into())]
+fn test_integer_sum_and_mean_stay_in_duckdb(
+    #[case] value: Scalar,
+    #[values("sum", "avg")] aggregate: &str,
+) -> VortexResult<()> {
+    let file = constant_file(value, 3)?;
+    let conn = connection()?;
+    let query = format!(
+        "EXPLAIN SELECT {aggregate}(i) FROM '{}'",
+        file.path().display(),
+    );
+    let mut plan = String::new();
+    for chunk in conn.query(&query)? {
+        for row in 0..chunk.len() {
+            let value = chunk
+                .get_vector(1)
+                .get_value(row, chunk.len())
+                .ok_or_else(|| vortex_err!("Expected an explain plan"))?;
+            plan.push_str(&value.as_string());
+        }
+    }
+    assert!(plan.contains("UNGROUPED_AGGREGATE"), "{plan}");
+
+    Ok(())
+}

--- a/vortex-duckdb/src/e2e_test/mod.rs
+++ b/vortex-duckdb/src/e2e_test/mod.rs
@@ -2,6 +2,8 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 #[cfg(test)]
+mod aggregate_pushdown_test;
+#[cfg(test)]
 mod s3_test;
 #[cfg(test)]
 mod spatial_pushdown_test;

--- a/vortex-duckdb/src/ffi.rs
+++ b/vortex-duckdb/src/ffi.rs
@@ -169,6 +169,7 @@ pub unsafe extern "C-unwind" fn duckdb_table_function_init_local(
 #[unsafe(no_mangle)]
 pub unsafe extern "C-unwind" fn duckdb_reader_bind(
     first_file: *const c_void,
+    single_file: bool,
     result: cpp::duckdb_bind_result,
     error_out: *mut cpp::duckdb_vx_error,
 ) -> cpp::duckdb_vx_data {
@@ -177,7 +178,7 @@ pub unsafe extern "C-unwind" fn duckdb_reader_bind(
     let mut result = unsafe { BindResult::own(result) };
 
     try_or_null(error_out, || {
-        let bind_data = reader_bind(first_file, &mut result)?;
+        let bind_data = reader_bind(first_file, single_file, &mut result)?;
         Ok(Data::from(Box::new(bind_data)).as_ptr())
     })
 }

--- a/vortex-duckdb/src/file_reader.rs
+++ b/vortex-duckdb/src/file_reader.rs
@@ -142,7 +142,13 @@ pub fn reader_open(file_path: &str) -> VortexResult<OpenFileReader> {
 /// with first file schema which is the scan schema. Unlike Parquet, we don't
 /// support schema evolution, so if any file schema doesn't match first schema,
 /// we break.
-pub fn reader_bind(file: &OpenFileReader, result: &mut BindResultRef) -> VortexResult<BindState> {
+///
+/// `single_file` must be true only when the initial scan contains exactly this file.
+pub fn reader_bind(
+    file: &OpenFileReader,
+    single_file: bool,
+    result: &mut BindResultRef,
+) -> VortexResult<BindState> {
     let dtype = file.reader.dtype().clone();
     let columns = extract_schema_from_dtype(&dtype)?;
 
@@ -153,6 +159,7 @@ pub fn reader_bind(file: &OpenFileReader, result: &mut BindResultRef) -> VortexR
     Ok(BindState {
         dtype,
         first_file_row_count: file.reader.row_count(),
+        max_row_count: single_file.then(|| file.reader.row_count()),
         filters: vec![],
         columns,
         has_non_optional_filter: AtomicBool::new(false),

--- a/vortex-duckdb/src/table_function.rs
+++ b/vortex-duckdb/src/table_function.rs
@@ -502,9 +502,9 @@ fn can_push_projection_aggregate(
 
     let mean_or_sum = matches!(aggregate, PushedAggregate::Sum | PushedAggregate::Mean);
 
-    // duckdb's sum() and avg() on i64/u64 accumulate in i128/u128, vortex
-    // sum()/avg() work on i64/u64 max and overflow to null
-    if mean_or_sum && dtype.is_primitive() && matches!(dtype.as_ptype(), PType::I64 | PType::U64) {
+    // DuckDB uses wider integer accumulators than Vortex's i64/u64 sum state. Even narrow
+    // integer inputs can overflow that state with enough rows, producing null instead of a value.
+    if mean_or_sum && dtype.is_int() {
         return false;
     }
 

--- a/vortex-duckdb/src/table_function.rs
+++ b/vortex-duckdb/src/table_function.rs
@@ -78,6 +78,8 @@ pub const COUNT_STAR_PROJ_IDX: u64 = u64::MAX;
 pub(crate) struct BindState {
     pub dtype: DType,
     pub first_file_row_count: u64,
+    /// Upper bound on scan rows, known only when binding a single file.
+    pub max_row_count: Option<u64>,
     pub filters: Vec<Expression>,
     pub columns: Vec<DuckdbField>,
     // There exists at least one non-optional table filter or at least one
@@ -95,6 +97,7 @@ impl Clone for BindState {
         Self {
             dtype: self.dtype.clone(),
             first_file_row_count: self.first_file_row_count,
+            max_row_count: self.max_row_count,
             filters: vec![],
             columns: self.columns.clone(),
             has_non_optional_filter: AtomicBool::new(
@@ -500,12 +503,21 @@ fn can_push_projection_aggregate(
         return false;
     }
 
-    let mean_or_sum = matches!(aggregate, PushedAggregate::Sum | PushedAggregate::Mean);
+    let mean_or_sum = matches!(
+        aggregate,
+        PushedAggregate::Sum | PushedAggregate::SumNoOverflow | PushedAggregate::Mean
+    );
 
-    // DuckDB uses wider integer accumulators than Vortex's i64/u64 sum state. Even narrow
-    // integer inputs can overflow that state with enough rows, producing null instead of a value.
-    if mean_or_sum && dtype.is_int() {
-        return false;
+    // Vortex's i64/u64 sum state must fit every partial, not just the final result. DuckDB's
+    // sum_no_overflow carries that proof. Otherwise, bound the sum using the input type and the
+    // unfiltered row count. Cardinality estimates cannot establish this guarantee.
+    if mean_or_sum && dtype.is_int() && *aggregate != PushedAggregate::SumNoOverflow {
+        let fits = bind_data
+            .max_row_count
+            .is_some_and(|rows| integer_sum_fits(dtype.as_ptype(), rows));
+        if !fits {
+            return false;
+        }
     }
 
     // duckdb decimal sum() overflows to error, vortex sum overflows to NULL
@@ -534,6 +546,19 @@ fn can_push_projection_aggregate(
     }
 
     true
+}
+
+/// Prove that every subset of at most `rows` values fits the integer sum state.
+fn integer_sum_fits(ptype: PType, rows: u64) -> bool {
+    let max_rows = if ptype.is_signed_int() {
+        // The negative limit is tighter: 2^63 / 2^(input_bits - 1).
+        1u64 << (64 - ptype.bit_width())
+    } else if ptype.is_unsigned_int() {
+        u64::MAX / ptype.max_value_as_u64()
+    } else {
+        return false;
+    };
+    rows <= max_rows
 }
 
 /// Turn a scan into an aggregate scan. Input is N aggregations, possibly over

--- a/vortex-sqllogictest/slt/duckdb/aggregate_pushdown.slt
+++ b/vortex-sqllogictest/slt/duckdb/aggregate_pushdown.slt
@@ -18,7 +18,7 @@ EXPLAIN
 SELECT sum(i), min(i), max(i), avg(i), mean(i), any_value(i), first(i), count(*), count(i)
 FROM '${WORK_DIR}/agg-pushdown.vortex';
 ----
-<!REGEX>:.*UNGROUPED_AGGREGATE.*
+<REGEX>:.*UNGROUPED_AGGREGATE.*
 
 query I
 SELECT sum(i) FROM '${WORK_DIR}/agg-pushdown.vortex';

--- a/vortex-sqllogictest/slt/duckdb/aggregate_pushdown.slt
+++ b/vortex-sqllogictest/slt/duckdb/aggregate_pushdown.slt
@@ -18,7 +18,7 @@ EXPLAIN
 SELECT sum(i), min(i), max(i), avg(i), mean(i), any_value(i), first(i), count(*), count(i)
 FROM '${WORK_DIR}/agg-pushdown.vortex';
 ----
-<REGEX>:.*UNGROUPED_AGGREGATE.*
+<!REGEX>:.*UNGROUPED_AGGREGATE.*
 
 query I
 SELECT sum(i) FROM '${WORK_DIR}/agg-pushdown.vortex';


### PR DESCRIPTION
## Summary

Aggregate pushdown changes valid DuckDB results into `NULL` because Vortex's 64-bit sum state can overflow before DuckDB's wider accumulator does. For 4,294,967,299 copies of `i32::MAX`, DuckDB returns `SUM = 9223372039002259453` and `AVG = 2147483647.0`, while the pushed aggregates both return `NULL`. An optimization must preserve the host engine's results.

## SQL semantics

The SQL standard leaves the exact numeric `SUM` result type implementation-defined and specifies a numeric-value-out-of-range exception for aggregate overflow. It does not require every engine to use 128-bit sums, but silently returning `NULL` is not the specified overflow behavior. See [SQL/Foundation, 2003 corrigendum, §8.1](https://cdn.standards.iteh.ai/samples/37833/600f10511a6d4d70b305701fd69ed417/ISO-IEC-9075-2-1999-Amd-1-2001-Cor-1-2003.pdf#page=8).

- [DuckDB](https://github.com/duckdb/duckdb/blob/v1.5.5/extension/core_functions/aggregate/distributive/sum.cpp) uses a `HUGEINT` accumulator for `SUM(INTEGER)`, so the example fits.
- [PostgreSQL](https://www.postgresql.org/docs/current/functions-aggregate.html) returns `bigint` for `SUM(integer)` and `numeric` for `SUM(bigint)`, so its numeric limits differ from DuckDB's.
- [SQLite](https://www.sqlite.org/lang_aggfunc.html#sumunc) raises an integer-overflow exception when an all-integer sum overflows. It returns `NULL` when there are no non-null inputs.

## Changes

Keeps integer `SUM` and `AVG` (including `mean`) pushdown when DuckDB's `sum_no_overflow` or the initial single-file row count and input type prove that every partial sum fits Vortex's 64-bit state. Otherwise, leaves aggregation in DuckDB without using estimated cardinalities as proof. Adds boundary, filter, and multi-file regressions, plus plan checks that preserve safe mixed-aggregate pushdown.
